### PR TITLE
replicate legacy setuptools behavior, add missing config mounts

### DIFF
--- a/pulsar/init.sh
+++ b/pulsar/init.sh
@@ -22,7 +22,7 @@ docker_run \
     -v "${PULSAR_ROOT}:/pulsar" \
     -v "${root}/pulsar/venv:/pulsar/.venv" \
     "$PULSAR_IMAGE" \
-    ./.venv/bin/pip install -e .
+    ./.venv/bin/pip install -e . --config-settings editable_mode=compat
 
 log "Installing Pulsar additional dependencies"
 docker_run \

--- a/remote-galaxy/init.sh
+++ b/remote-galaxy/init.sh
@@ -18,5 +18,7 @@ log "Updating remote Galaxy venv for remote metadata"
 docker_run \
     -v "${GALAXY_ROOT}:/remote-galaxy:ro" \
     -v "${root}/remote-galaxy/venv:/remote-galaxy/.venv" \
+    -v "${root}/galaxy/config/galaxy.yml:/remote-galaxy/config/galaxy.yml:ro" \
+    -v "${root}/galaxy/config/job_conf.yml:/remote-galaxy/config/job_conf.yml:ro" \
     "$PULSAR_IMAGE" \
     bash ./scripts/common_startup.sh --skip-client-build


### PR DESCRIPTION
replicate legacy setuptools behavior: https://setuptools.pypa.io/en/latest/userguide/development_mode.html#legacy-behavior
add missing config mounts